### PR TITLE
Fix code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,6 +3,9 @@ from flask_cors import CORS
 import psycopg2
 import json
 from datetime import date, datetime
+import logging
+
+logging.basicConfig(level=logging.ERROR, format='%(asctime)s %(levelname)s %(message)s')
 
 app = Flask(__name__)
 CORS(app, resources={r"/api/*": {"origins": "*"}})
@@ -80,7 +83,8 @@ def get_data():
         connection.close()
         return Response(json.dumps(result, default=json_serial), mimetype='application/json')
     except Exception as e:
-        return Response(json.dumps({"error": str(e)}), status=500, mimetype='application/json')
+        logging.error("An error occurred in get_data: %s", str(e))
+        return Response(json.dumps({"error": "An internal error has occurred!"}), status=500, mimetype='application/json')
 
 
 @app.route('/api/dataById', methods=['GET'])
@@ -122,7 +126,8 @@ def get_data_by_id():
         return Response(json.dumps(result, default=json_serial), mimetype='application/json')
 
     except Exception as e:
-        return Response(json.dumps({"error": str(e)}), status=500, mimetype='application/json')
+        logging.error("An error occurred in get_data_by_id: %s", str(e))
+        return Response(json.dumps({"error": "An internal error has occurred!"}), status=500, mimetype='application/json')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes [https://github.com/fatihtekik/IUnderstand-now/security/code-scanning/5](https://github.com/fatihtekik/IUnderstand-now/security/code-scanning/5)

To fix the problem, we need to ensure that detailed error information is logged on the server side while returning a generic error message to the user. This can be achieved by logging the exception details using a logging library and returning a generic error message in the response.

- Import the `logging` module to log error details.
- Configure the logging settings to log errors to a file or console.
- Replace the current exception handling code to log the exception details and return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
